### PR TITLE
slots no name bug fix

### DIFF
--- a/app/quizTableOfElements/page.tsx
+++ b/app/quizTableOfElements/page.tsx
@@ -193,6 +193,7 @@ const QuizTableOfElements: React.FC = () => {
                   number={numberActive ? item.number : 0}
                   category={item?.category}
                   onSlotElementPress={function (name: string): void {
+                    if(name === "no name") return; // without this empty cards turnn red. so do nothing when clicked
                     if (name === target?.name) {
                       setGreenCards(new Set(greenCards).add(name)); // Add the correct card to greenCards
                       setRedCards(new Set()); // Reset red cards


### PR DESCRIPTION
Bug fixed: When an empty slot is clicked, it turns red.
added a condition to handle a slot click: if slot has no name, do nothing